### PR TITLE
Update google format dependency and use protobuf json marshaler.

### DIFF
--- a/integration/go-http-client/client_test.go
+++ b/integration/go-http-client/client_test.go
@@ -16,7 +16,6 @@ package interop
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -24,17 +23,19 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/protobuf/jsonpb"
+
 	"golang.org/x/net/context"
 
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
-	"go.opencensus.io/plugin/ochttp/propagation/google"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 
 	pb "github.com/census-instrumentation/opencensus-experiments/integration/src/main/proto"
+	google "go.opencensus.io/exporter/stackdriver/propagation"
 )
 
 var setups = []struct {
@@ -47,6 +48,8 @@ var setups = []struct {
 }
 
 var propagations = []string{"b3", "google", "tracecontext"}
+
+var jsonUnmarshaler = jsonpb.Unmarshaler{}
 
 func TestInterop(t *testing.T) {
 	for _, setup := range setups {
@@ -113,7 +116,7 @@ func runInteropTest(t *testing.T, host, propagationStr string) {
 		t.Fatalf("Response.Body read err: %v", err)
 	}
 	eres := new(pb.EchoResponse)
-	if err := json.Unmarshal(blob, eres); err != nil {
+	if err := jsonUnmarshaler.Unmarshal(bytes.NewReader(blob), eres); err != nil {
 		t.Fatalf("UnmarshalJSON err: %v", err)
 	}
 


### PR DESCRIPTION
This PR addresses the following issues:
1. use `golang/protobuf/jsonpub` as marshaler/unmarshaler - the default `encoding/json` cannot handle camelCase json generated by Java server.
2. update the dependency of google cloud-trace format since it is moved to another package (https://github.com/census-instrumentation/opencensus-go/pull/555).

Though this change is tested locally, it is my first time writing in Golang. Please pardon me if I make any mistakes :)