### PR TITLE
 Install latest OpenCensus Java version in Makefile and update dependency

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,8 +1,12 @@
 .PHONY: start_go_servers start_java_servers run_go_client_tests run_java_client_tests
-test: gen_proto gradlew_install start_go_servers start_java_servers run_go_client_tests run_java_client_tests
+test: gen_proto gradlew_install_opencensus gradlew_install start_go_servers start_java_servers run_go_client_tests run_java_client_tests
 
 gen_proto:
 	protoc -I proto/ proto/defs.proto --go_out=plugins=grpc:proto
+
+gradlew_install_opencensus:
+	# Install the latest OpenCensus-Java version locally.
+	git clone https://github.com/census-instrumentation/opencensus-java.git && cd opencensus-java && ./gradlew install && cd .. && rm -rf opencensus-java
 
 gradlew_install:
 	# To use a different OpenCensus and gRPC version, use -PopencensusVersion= and -PgrpcVersion=.

--- a/integration/java/build.gradle
+++ b/integration/java/build.gradle
@@ -29,11 +29,10 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.13.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.13.0-SNAPSHOT" // LATEST_OPENCENSUS_VERSION we want to test.
-def grpcVersion = "1.9.0" // CURRENT_GRPC_VERSION
-def guavaVersion = "19.0"
+def grpcVersion = "1.10.0" // CURRENT_GRPC_VERSION
+def guavaVersion = "20.0"
 
 if (project.hasProperty("opencensusVersion")) {
     opencensusVersion = project.properties["opencensusVersion"]


### PR DESCRIPTION
Our goal should be to test the latest snapshot of the github repo, rather than the released maven jars. Add a step to clone and install latest OpenCensus Java version in Makefile, and update Java interop build dependencies to be consistent with v0.13.0-SNAPSHOT.