### PR TITLE
Do not verify method tag in gRPC interop test.

### DIFF
--- a/integration/java/grpc/io/opencensus/interop/grpc/GrpcInteropTestClient.java
+++ b/integration/java/grpc/io/opencensus/interop/grpc/GrpcInteropTestClient.java
@@ -54,11 +54,8 @@ public final class GrpcInteropTestClient {
   private static final String SPAN_NAME = "gRPC-client-span";
   private static final TagKey OPERATION_KEY = TagKey.create("operation");
   private static final TagKey PROJECT_KEY = TagKey.create("project");
-  private static final TagKey METHOD_KEY = TagKey.create("method");
   private static final TagValue OPERATION_VALUE = TagValue.create("interop-test");
   private static final TagValue PROJECT_VALUE = TagValue.create("open-census");
-  private static final TagValue METHOD_VALUE =
-      TagValue.create(EchoServiceGrpc.getEchoMethod().getFullMethodName());
 
   private GrpcInteropTestClient(int serverPort) {
     this.serverPort = serverPort;
@@ -85,7 +82,7 @@ public final class GrpcInteropTestClient {
       EchoResponse response = stub.echo(EchoRequest.getDefaultInstance());
 
       SpanContext expectedSpanContext = tracer.getCurrentSpan().getContext();
-      TagContext expectedTagContext = tagger.currentBuilder().put(METHOD_KEY, METHOD_VALUE).build();
+      TagContext expectedTagContext = tagger.currentBuilder().build();
       succeeded = TestUtils.verifyResponse(expectedSpanContext, expectedTagContext, response);
     } catch (Exception e) {
       logger.log(Level.SEVERE, "Exception thrown when sending request.", e);

--- a/integration/java/util/io/opencensus/interop/util/TestUtils.java
+++ b/integration/java/util/io/opencensus/interop/util/TestUtils.java
@@ -153,6 +153,8 @@ public class TestUtils {
         TagContext actualTagContext =
             serializer.fromByteArray(response.getTagsBlob().toByteArray());
         Set<Tag> actualTags = Sets.<Tag>newHashSet(InternalUtils.getTags(actualTagContext));
+        // TODO(songya): method tag should be non-propagate. Remove this line once method tag is no
+        // longer propagated in gRPC-Java.
         actualTags.remove(Tag.create(METHOD_KEY, METHOD_VALUE));
         Set<Tag> expectedTags = Sets.<Tag>newHashSet(InternalUtils.getTags(expectedTagContext));
         if (!actualTags.equals(expectedTags)) {

--- a/integration/java/util/io/opencensus/interop/util/TestUtils.java
+++ b/integration/java/util/io/opencensus/interop/util/TestUtils.java
@@ -18,13 +18,16 @@ package io.opencensus.interop.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import io.opencensus.contrib.http.util.HttpPropagationUtil;
 import io.opencensus.interop.EchoResponse;
+import io.opencensus.interop.EchoServiceGrpc;
 import io.opencensus.tags.InternalUtils;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tags;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextDeserializationException;
@@ -33,6 +36,7 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.propagation.TextFormat;
 import java.math.BigInteger;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,6 +44,10 @@ import java.util.logging.Logger;
 public class TestUtils {
 
   private static final Logger logger = Logger.getLogger(TestUtils.class.getName());
+
+  private static final TagKey METHOD_KEY = TagKey.create("method");
+  private static final TagValue METHOD_VALUE =
+      TagValue.create(EchoServiceGrpc.getEchoMethod().getFullMethodName());
 
   private TestUtils() {}
 
@@ -144,13 +152,14 @@ public class TestUtils {
       try {
         TagContext actualTagContext =
             serializer.fromByteArray(response.getTagsBlob().toByteArray());
-        if (!actualTagContext.equals(expectedTagContext)) {
+        Set<Tag> actualTags = Sets.<Tag>newHashSet(InternalUtils.getTags(actualTagContext));
+        actualTags.remove(Tag.create(METHOD_KEY, METHOD_VALUE));
+        Set<Tag> expectedTags = Sets.<Tag>newHashSet(InternalUtils.getTags(expectedTagContext));
+        if (!actualTags.equals(expectedTags)) {
           succeeded = false;
           logger.severe(
               String.format(
-                  "Client received wrong TagContext. Got %s, want %s.",
-                  Lists.<Tag>newArrayList(InternalUtils.getTags(actualTagContext)),
-                  Lists.<Tag>newArrayList(InternalUtils.getTags(expectedTagContext))));
+                  "Client received wrong TagContext. Got %s, want %s.", actualTags, expectedTags));
         }
       } catch (TagContextDeserializationException e) {
         succeeded = false;


### PR DESCRIPTION
Temporarily fix the interop test failure between Java and Go gRPC tests because gRPC-Go doesn't propagate method tag. In the long term, we may want to make all tags non-propagate by default in Java.

/cc @dinooliva 